### PR TITLE
Resolve "Could not find class" error when using android::addon

### DIFF
--- a/manifests/addon.pp
+++ b/manifests/addon.pp
@@ -11,7 +11,6 @@
 # Copyright 2012 MaestroDev, unless otherwise noted.
 #
 define android::addon() {
-  include android::package
 
   android::package{ $title:
     type => 'addon',


### PR DESCRIPTION
Hello! I think I have found (and fixed?) a bug in this module.

In my Puppet manifest:

``` puppet
    android::addon {
        'addon-google_apis-google-17': ;
        'addon-google_apis-google-8':  ;
    }
```

I get the following error from Puppet:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Could not find class android::package for hostname on node hostname
```

Removing the include line in android::addon (it's not present in the similar android::platform) resolves this issue for me.
