### PR TITLE
Add detect for ubuntu 14.04 and dont install ia32-libs

### DIFF
--- a/manifests/sdk.pp
+++ b/manifests/sdk.pp
@@ -53,4 +53,8 @@ class android::sdk {
       default  => [],
     })
   }
+
+  if $lsbdistrelease == 14.04 {
+    ensure_packages(["libc6-i386", "lib32stdc++6", "lib32gcc1", "lib32ncurses5", "lib32z1"])
+  }
 }


### PR DESCRIPTION
- Resolves issue with installing non-existent ia32-libs libs in ubuntu 14.04
