### PR TITLE
Return an error on failed packages

### DIFF
--- a/templates/expect-script.erb
+++ b/templates/expect-script.erb
@@ -2,5 +2,6 @@ set timeout -1;
 spawn <%= scope.lookupvar('android::paths::sdk_home') %>/tools/android update sdk -u --all -t <%= @title %> <%= @proxy_host %> <%= @proxy_port %>; 
 expect { 
     "Do you accept the license" { exp_send "y\r" ; exp_continue }
+    "Error: Ignoring unknown package" { exit 1 }
     eof
 }


### PR DESCRIPTION
This patch covers the case when the android update command fails to find a package (due to either the user entering an invalid package name in a manifest, or the android tool itself not being up to date so it can't find a new package).

Expect will catch the error text, exit with a non-zero error code, which the puppet exec command will register as an error.
