### PR TITLE
Remove dependency on expect package.

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -53,19 +53,12 @@ define android::package($type) {
     }
   }
 
-  case $::kernel {
-    'Darwin': {}
-    default: {
-      ensure_packages(['expect'])
-      Package['expect'] -> Exec["update-android-package-${title}"]
-    }
-  }
-
   file { "${android::installdir}/expect-install-${title}":
     content => template("android/expect-script.erb"),
+    mode    => '0755',
   } ->
   exec { "update-android-package-${title}":
-    command => "/usr/bin/expect -f ${android::installdir}/expect-install-${title}",
+    command => "${android::installdir}/expect-install-${title}",
     creates => $creates,
     timeout => 0,
     require => [Class['android::sdk']],

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -20,7 +20,7 @@ describe "android" do
     it { should contain_file("#{dir}/expect-install-platform-tools")
       .with_content(/android update sdk -u --all -t platform-tools/) }
     it { should contain_exec('update-android-package-platform-tools')
-      .with_command("/usr/bin/expect -f #{dir}/expect-install-platform-tools") }
+      .with_command("#{dir}/expect-install-platform-tools") }
 
     it { should contain_file(dir).with( { :owner => 'root', :group => 'root' }) }
     it { should contain_exec('unpack-androidsdk').with( { :cwd => dir, :user => 'root' } ) }
@@ -47,7 +47,7 @@ describe "android" do
     it { should contain_file("#{dir}/expect-install-platform-tools")
       .with_content(/android update sdk -u --all -t platform-tools --proxy-host myhost --proxy-port 1234/) }
     it { should contain_exec('update-android-package-platform-tools')
-      .with_command("/usr/bin/expect -f #{dir}/expect-install-platform-tools") }
+      .with_command("#{dir}/expect-install-platform-tools") }
   end
 
   context 'with installdir', :compile do
@@ -100,7 +100,7 @@ describe "android" do
     it { should contain_file("#{dir}/expect-install-platform-tools")
       .with_content(/android update sdk -u --all -t platform-tools --proxy-host myhost --proxy-port 1234/) }
     it { should contain_exec('update-android-package-platform-tools')
-      .with_command("/usr/bin/expect -f #{dir}/expect-install-platform-tools") }
+      .with_command("#{dir}/expect-install-platform-tools") }
 
     it { should contain_file(dir).with( { :owner => 'root', :group => 'admin' }) }
     it { should contain_exec('unpack-androidsdk').with( { :cwd => dir,:user => 'root' } ) }

--- a/spec/defines/package_spec.rb
+++ b/spec/defines/package_spec.rb
@@ -10,7 +10,7 @@ describe 'android::package' do
     it { should contain_file("#{dir}/expect-install-android-15")
       .with_content(/android update sdk -u --all -t android-15/) }
     it { should contain_exec('update-android-package-android-15').with({
-      :command => "/usr/bin/expect -f #{dir}/expect-install-android-15",
+      :command => "#{dir}/expect-install-android-15",
       :creates => "#{dir}/android-sdk-linux/platforms/android-15",
     }) }
   end
@@ -34,7 +34,7 @@ describe 'android::package' do
     let(:params) { { :type => 'platform' } }
     it { should contain_file("#{dir}/expect-install-android-15").with_content(/android update sdk -u --all -t android-15/) }
     it { should contain_exec('update-android-package-android-15').with({
-      :command => "/usr/bin/expect -f #{dir}/expect-install-android-15",
+      :command => "#{dir}/expect-install-android-15",
       :creates => "#{dir}/android-sdk-macosx/platforms/android-15",
     }) }
   end

--- a/templates/expect-script.erb
+++ b/templates/expect-script.erb
@@ -1,7 +1,27 @@
-set timeout -1;
-spawn <%= scope.lookupvar('android::paths::sdk_home') %>/tools/android update sdk -u --all -t <%= @title %> <%= @proxy_host %> <%= @proxy_port %>; 
-expect { 
-    "Do you accept the license" { exp_send "y\r" ; exp_continue }
-    "Error: Ignoring unknown package" { exit 1 }
-    eof
-}
+#!/usr/bin/env ruby
+
+require 'pty'
+require 'expect'
+
+command="<%= scope.lookupvar('android::paths::sdk_home') %>/tools/android update sdk -u --all -t <%= @title %> <%= @proxy_host %> <%= @proxy_port %>"
+match=%r/^\s*Do you accept the license .* \[y\/n\]:\s*/
+response="y"
+
+puts command
+
+PTY.spawn(command) do |r,w,p|
+
+  w.sync = true
+
+  begin
+    while true do
+      r.expect(match)
+      sleep(0.1)
+      w.puts(response)
+    end
+  rescue Errno::EIO, PTY::ChildExited
+  end
+end
+
+exit
+#  vim: set ts=2 sw=2 tw=0 et:


### PR DESCRIPTION
Instead, use ruby PTY and expect.

I'm not _totally_ sure about this one and I'm happy to debate its merits.

My goal here was to avoid having the extra delay of installing expect on CI systems/agents that don't already have it.
