### PR TITLE
Add package revision parameter, fix NDK install, check package exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,66 @@
-Puppet Module for Android SDK
-=============================
+Puppet Module for Android SDK and NDK
+=====================================
 
 [![Build Status](https://maestro.maestrodev.com/api/v1/projects/58/compositions/443/badge/icon)](https://maestro.maestrodev.com/projects/58/compositions/443)
 
-This Puppet module is used to install the Android SDK and NDK, 
-along with platforms and other add-ons.
-You may need to install Java separately.
+This Puppet module is used to install the Android SDK and NDK, along with
+add-ons, build-tools, extras, platforms, and system images. You may need to
+install Java separately.
 
 Supported platforms:
 
 * Linux (RedHat, Debian families)
-* Mac OS X
+* OS X (requires `wget` to be installed)
 
 Examples
 --------
 
-To install the Android SDK in the default location (/usr/local/android on both Linux
-and Mac OS X) you simply include the android class like so.
+To install the Android SDK and platform tools in the default location
+(`/usr/local/android` on both Linux and OS X) you simply include the `android`
+class like so:
 
-    class { 'java': } ->
-    class { 'android': }
+```
+class { 'java': } ->
+class { 'android': }
+```
 
 You can also change the default parameters like so:
 
 ```
-  class { 'android':
-    user       => 'someuser',
-    group      => 'somegroup',
-    installdir => '/path/to/your/dir',
-  }
+class { 'android':
+  user       => 'someuser',
+  group      => 'somegroup',
+  installdir => '/path/to/your/dir',
+}
 ```
 
 You can install the Android NDK like so:
 
 ```
-class { 'android::ndk' :
+class { 'android::ndk':
   ndk_version => 'android-ndk-r10c-linux-x86_64.bin'
 }
 ```
 
-Note that the NDK is downloaded and executed, so only newer NDK versions are supported. The older tar archives will not work properly.
+Note that the Android NDK is downloaded and executed, so only newer NDK
+versions are supported. The older tar archives will not work properly.
 
-To install an android platform, do it like so:
+To install an Android Platform, do it like so:
 
 ```
-  android::platform { 'android-16': }
+android::platform { 'android-16': }
 ```
 
 You can also install add-ons:
 
 ```
-  android::addon { 'addon-google_apis-google-16': }
+android::addon { 'addon-google_apis-google-16': }
 ```
 
-Or extra's:
+Or extras:
 
 ```
-  android::extra { 'extra-google-play_billing': }
+android::extra { 'extra-google-play_billing': }
 ```
 
 Or system images:
@@ -65,10 +69,10 @@ Or system images:
 android::system_images { 'sys-img-armeabi-v7a-android-23': }
 ```
 
-To install Android SDK Build-tools, revision 19.0.1
+To install the Android SDK Build-tools, revision 19.0.1:
 
 ```
-  android::build_tools { 'build-tools-19.0.1': }
+android::build_tools { 'build-tools-19.0.1': }
 ```
 
 For add-ons, extras, platforms, and system images, the revision number can be
@@ -106,18 +110,19 @@ android list sdk --all --extended --no-ui | grep " or "
 
 License
 -------
+
 ```
-  Copyright 2012-2014 MaestroDev
+Copyright 2012-2016 MaestroDev
 
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 ```

--- a/README.md
+++ b/README.md
@@ -59,16 +59,49 @@ Or extra's:
   android::extra { 'extra-google-play_billing': }
 ```
 
+Or system images:
+
+```
+android::system_images { 'sys-img-armeabi-v7a-android-23': }
+```
+
 To install Android SDK Build-tools, revision 19.0.1
 
 ```
   android::build_tools { 'build-tools-19.0.1': }
 ```
 
-Tip: to get the appropriate name of the add-ons/extras run the following command:
+For add-ons, extras, platforms, and system images, the revision number can be
+specified using the optional `revision` parameter:
 
 ```
-/usr/local/android/android-sdk-macosx/tools/android list sdk -u --all --extended|grep " or "
+android::extra { 'extra-google-m2repository':
+  revision => '24',
+}
+```
+
+The add-on, extra, platform, or system image will only be upgraded only if the
+installed revision is not equal to the specified revision. For build-tools, the
+revision number forms part of the name of the build-tool, hence there is no
+`revision` parameter.
+
+The `revision` parameter can also take the value `present` that initially
+installs the latest version of the add-on, extra, platform, or system image, but
+does not upgrade it when a new version becomes available, and the value `latest`
+that always upgrades the add-on, extra, platform, or system image to the latest
+version:
+
+```
+android::extra { 'extra-android-m2repository':
+  revision => latest,
+}
+```
+
+Tip: To get the appropriate name of the add-on, extra, platform, or system
+image, run the following command:
+
+```
+android list sdk --all --extended --no-ui | grep " or "
 ```
 
 License

--- a/manifests/addon.pp
+++ b/manifests/addon.pp
@@ -2,6 +2,16 @@
 #
 # Installs an Android SDK add-on package.
 #
+# === Examples
+#
+# To install an add-on package:
+#   android::addon { 'addon-google_apis-google-16': }
+#
+# === Parameters
+#
+# [*revision*] The revision number of the specified add-on package or a value of
+#   'latest' or 'present'
+#
 # === Authors
 #
 # Etienne Pelletier <epelletier@maestrodev.com>

--- a/manifests/addon.pp
+++ b/manifests/addon.pp
@@ -10,10 +10,12 @@
 #
 # Copyright 2012 MaestroDev, unless otherwise noted.
 #
-define android::addon() {
+define android::addon(
+  $revision = 'present',
+) {
 
-  android::package{ $title:
-    type => 'addon',
+  android::package { $title:
+    revision => $revision,
+    type     => 'addon',
   }
-
 }

--- a/manifests/build_tools.pp
+++ b/manifests/build_tools.pp
@@ -1,6 +1,11 @@
-# == Class: android::build_tools
+# == Define: android::build_tools
 #
-# Installs the Android SDK build-tools.
+# Installs an Android SDK build-tools package.
+#
+# === Examples
+#
+# To install a build-tools package:
+#   android::build_tools { 'build-tools-19.0.1': }
 #
 # === Authors
 #
@@ -8,7 +13,7 @@
 #
 # === Copyright
 #
-# Copyright 2013 Philip Schiffer
+# Copyright 2013 Philip Schiffer.
 #
 define android::build_tools() {
 

--- a/manifests/build_tools.pp
+++ b/manifests/build_tools.pp
@@ -12,8 +12,7 @@
 #
 define android::build_tools() {
 
-  android::package{ $title:
+  android::package { $title:
     type => 'build-tools',
   }
-
 }

--- a/manifests/extra.pp
+++ b/manifests/extra.pp
@@ -1,6 +1,16 @@
 # == Define: android::extra
 #
-# Installs an Android SDK "extra's" package.
+# Installs an Android SDK extra package.
+#
+# === Examples
+#
+# To install an extra package:
+#   android::extra { 'extra-google-play_billing': }
+#
+# === Parameters
+#
+# [*revision*] The revision number of the specified extra package or a value of
+#   'latest' or 'present'
 #
 # === Authors
 #

--- a/manifests/extra.pp
+++ b/manifests/extra.pp
@@ -10,10 +10,12 @@
 #
 # Copyright 2012 MaestroDev, unless otherwise noted.
 #
-define android::extra() {
+define android::extra(
+  $revision = 'present',
+) {
 
-  android::package{ $title:
-    type => 'extra',
+  android::package { $title:
+    revision => $revision,
+    type     => 'extra',
   }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,8 @@ class android(
   $group      = $android::params::group,
   $installdir = $android::params::installdir,
   $proxy_host = $android::params::proxy_host,
-  $proxy_port = $android::params::proxy_port) inherits android::params {
+  $proxy_port = $android::params::proxy_port,
+) inherits android::params {
 
   validate_re($version, '^\d+(?:\.\d+)*$', "Invalid version: ${version}")
   validate_string($user)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,15 +1,25 @@
 # == Class: android
 #
-# This class is used to install the android SDK and platform tools
+# This class is used to install the Android SDK and platform tools.
 #
-# === Parameters:
+# === Examples
 #
-# [*version*] the SDK version
-# [*user*] used to set the file ownership of the installed SDK
-# [*group*] used to set the file ownership of the installed SDK
-# [*installdir*] the install directory.
-# [*proxy_host*] the proxy server host name (used by the android tool)
-# [*proxy_port*] the proxy server port (used by the android tool)
+# To install the Android SDK:
+#   class { 'java': } ->
+#   class { 'android':
+#     user       => 'someuser',
+#     group      => 'somegroup',
+#     installdir => '/path/to/your/dir',
+#   }
+#
+# === Parameters
+#
+# [*version*] The SDK version
+# [*user*] Used to set the file ownership of the installed SDK
+# [*group*] Used to set the file ownership of the installed SDK
+# [*installdir*] The install directory
+# [*proxy_host*] The proxy server host name (used by the 'android' tool)
+# [*proxy_port*] The proxy server port (used by the 'android' tool)
 #
 # === Authors
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,19 @@ class android(
   $proxy_host = $android::params::proxy_host,
   $proxy_port = $android::params::proxy_port) inherits android::params {
 
+  validate_re($version, '^\d+(?:\.\d+)*$', "Invalid version: ${version}")
+  validate_string($user)
+  validate_string($group)
+  validate_absolute_path($installdir)
+
+  if ($proxy_host != undef) {
+    validate_string($proxy_host, '^\d+$')
+  }
+
+  if ($proxy_port != undef) {
+    validate_re($proxy_port, '^\d+$', "Invalid proxy port: ${proxy_port}")
+  }
+
   anchor { 'android::begin': } ->
   class { 'android::paths': } ->
   class { 'android::sdk': } ->

--- a/manifests/ndk.pp
+++ b/manifests/ndk.pp
@@ -18,6 +18,9 @@ class android::ndk(
   $ndk_version = $android::params::ndk_version
 )
 {
+
+  validate_re($ndk_version, '\.bin$')
+
   include android::paths
   include android::params
   include wget

--- a/manifests/ndk.pp
+++ b/manifests/ndk.pp
@@ -1,10 +1,21 @@
 # == Class: android::ndk
 #
 # This downloads and unpacks the Android NDK from Google's download
-# sever, or another specified server.
+# server, or another specified server.
 #
-# Note that the NDK is expected to be a self extracting, so the
-# older .tar.gz packages that are simply extracted will not be supported.
+# Note that the NDK is expected to be a self extracting, so the older '.tar.gz'
+# packages that are simply extracted will not be supported.
+#
+# === Examples
+#
+# To install the Android NDK r10c-linux-x86_64:
+#   class { 'android::ndk':
+#     ndk_version => 'android-ndk-r10c-linux-x86_64.bin'
+#   }
+#
+# === Parameters
+#
+# [*ndk_version*] The NDK version and architecture to install
 #
 # === Authors
 #

--- a/manifests/ndk.pp
+++ b/manifests/ndk.pp
@@ -18,17 +18,23 @@ class android::ndk(
   $ndk_version = $android::params::ndk_version
 )
 {
+  include android::paths
   include android::params
   include wget
 
+  if ( $::id == 'root' ) {
+    Exec { user => $android::user }
+  }
+
   $base_path = "http://dl.google.com/android/ndk/${ndk_version}"
   $ndk_installer = "${android::paths::installdir}/${ndk_version}"
+
   wget::fetch { 'download-androidndk':
     source      => $base_path,
     destination => $ndk_installer,
   } ->
   file { 'android-ndkexecutable':
-    ensure => present,
+    ensure => file,
     path   => $ndk_installer,
     owner  => $android::user,
     group  => $android::group,
@@ -36,7 +42,7 @@ class android::ndk(
   } ->
   exec { 'run-androidndk':
     command => "${ndk_installer} -y",
+    creates => regsubst($ndk_installer, '^(.*)\.bin$','\1'),
     cwd     => $android::params::installdir,
   }
-
 }

--- a/manifests/ndk.pp
+++ b/manifests/ndk.pp
@@ -15,9 +15,8 @@
 # Copyright 2015 Sam Kerr, unless otherwise noted.
 #
 class android::ndk(
-  $ndk_version = $android::params::ndk_version
-)
-{
+  $ndk_version = $android::params::ndk_version,
+) {
 
   validate_re($ndk_version, '\.bin$')
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,11 +1,27 @@
 # == Define: android::package
 #
-# This defined resource is used to install Android SDK packages
+# This defined resource is used to install Android SDK packages.
+#
+# === Examples
+#
+# To install the latest revision of a package:
+#   android::package { 'extra-android-m2repository':
+#     type     => 'extra',
+#     revision => 'latest',
+#   }
+#
+# To install a specified revision of a package:
+#   android::package { 'extra-android-m2repository':
+#     type     => 'extra',
+#     revision => '24',
+#   }
 #
 # === Parameters
 #
-# [*type*] One of platform-tools, platform, addon, extra or build-tools. Indicates
-# the type of package to install.
+# [*type*] The type of package to install. This must be 'addon', 'build-tools',
+#   'extra', 'platform', 'platform-tools', or 'system-images'.
+# [*revision*] The revision number of the specified package or a value of
+#   'latest' or 'present'
 #
 # === Authors
 #

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -15,7 +15,11 @@
 #
 # Copyright 2012 MaestroDev, unless otherwise noted.
 #
-define android::package($type) {
+define android::package(
+  $type,
+  $revision = 'present',
+) {
+
   include android
 
   if ( $::id == 'root' ) {
@@ -27,28 +31,49 @@ define android::package($type) {
 
   case $type {
     'platform-tools': {
-      $creates = "${android::paths::sdk_home}/platform-tools"
+      $path = "${android::paths::sdk_home}/platform-tools"
     }
     'platform': {
-      $creates = "${android::paths::sdk_home}/platforms/${title}"
+      $path = "${android::paths::sdk_home}/platforms/${title}"
     }
     'system-images': {
       $title_parts = split($title, '-')
-      $creates = "${android::paths::sdk_home}/system-images/android-${title_parts[-1]}/default/${title_parts[2]}-${title_parts[3]}"
+      $path = "${android::paths::sdk_home}/system-images/android-${title_parts[-1]}/default/${title_parts[2]}-${title_parts[3]}"
     }
     'addon': {
-      $creates = "${android::paths::sdk_home}/add-ons/${title}"
+      $path = "${android::paths::sdk_home}/add-ons/${title}"
     }
     'extra': {
       $title_parts = split($title, '-')
-      $creates = "${android::paths::sdk_home}/extras/${title_parts[1]}/${title_parts[2]}"
+      $path = "${android::paths::sdk_home}/extras/${title_parts[1]}/${title_parts[2]}"
     }
     'build-tools': {
       $title_parts = split($title, '-')
-      $creates = "${android::paths::sdk_home}/build-tools/${title_parts[2]}"
+      $path = "${android::paths::sdk_home}/build-tools/${title_parts[2]}"
     }
     default: {
       fail("Unsupported package type: ${type}")
+    }
+  }
+
+  case $revision {
+    'latest': {
+      $creates = undef
+      $onlyif = "${android::paths::sdk_home}/tools/android list sdk --extended --no-ui ${proxy_host} ${proxy_port} | grep ${title}"
+      $unless = undef
+    }
+    'present': {
+      $creates = $path
+      $onlyif = undef
+      $unless = undef
+    }
+    /^\d+(?:\.\d+)*$/: {
+      $creates = undef
+      $onlyif = undef
+      $unless = "grep 'Pkg.Revision=${revision}' ${path}/source.properties"
+    }
+    default: {
+      fail("Invalid package revision: ${revision}")
     }
   }
 
@@ -59,8 +84,10 @@ define android::package($type) {
   exec { "update-android-package-${title}":
     command => "${android::installdir}/expect-install-${title}",
     creates => $creates,
+    onlyif  => $onlyif,
+    path    => ['/bin', '/usr/bin'],  # For grep.
     timeout => 0,
-    require => [Class['android::sdk']],
+    unless  => $unless,
+    require => Class['android::sdk'],
   }
-
 }

--- a/manifests/paths.pp
+++ b/manifests/paths.pp
@@ -1,7 +1,7 @@
-# === Class: android::paths
+# == Class: android::paths
 #
-# This class defines the paths used in the Android SDK installation
-# and operation.
+# This class defines the paths used in the Android SDK installation and
+# operation.
 #
 # === Authors
 #

--- a/manifests/platform.pp
+++ b/manifests/platform.pp
@@ -10,10 +10,12 @@
 #
 # Copyright 2012 MaestroDev, unless otherwise noted.
 #
-define android::platform() {
+define android::platform(
+  $revision = 'present',
+) {
 
-  android::package{ $title:
-    type => 'platform',
+  android::package { $title:
+    revision => $revision,
+    type     => 'platform',
   }
-
 }

--- a/manifests/platform.pp
+++ b/manifests/platform.pp
@@ -2,6 +2,16 @@
 #
 # Installs an Android SDK platform package.
 #
+# === Examples
+#
+# To install a platform package:
+#   android::platform { 'android-16': }
+#
+# === Parameters
+#
+# [*revision*] The revision number of the specified platform package or a value
+#   of 'latest' or 'present'
+#
 # === Authors
 #
 # Etienne Pelletier <epelletier@maestrodev.com>

--- a/manifests/platform_tools.pp
+++ b/manifests/platform_tools.pp
@@ -12,8 +12,7 @@
 #
 class android::platform_tools {
 
-  android::package{ 'platform-tools':
+  android::package { 'platform-tools':
     type => 'platform-tools',
   }
-
 }

--- a/manifests/sdk.pp
+++ b/manifests/sdk.pp
@@ -56,9 +56,9 @@ class android::sdk {
 
   # For 64-bit systems, we need to install some 32-bit libraries for the SDK
   # to work.
-  if ($::kernel == 'Linux') and ($::architecture == 'x86_64' or $::architecture == 'amd64') and $::lsbdistrelease != '14.04' {
-    ensure_packages($::osfamily ? {
-      'RedHat' => ['glibc.i686','zlib.i686','libstdc++.i686','zlib','libstdc++'],
+  if ($::kernel == 'Linux') and ($::architecture == 'x86_64' or $::architecture == 'amd64')
+    and ($::lsbdistid != 'Ubuntu' or versioncmp($::lsbdistrelease, '14.04') < 0)
+    and ($::lsbdistid != 'Debian' or versioncmp($::lsbdistrelease, '7.0') < 0) {
 
     $packages = $::osfamily ? {
       # List 64-bit version and use latest for installation too so that the same
@@ -71,7 +71,9 @@ class android::sdk {
     ensure_packages($packages)
   }
 
-  if $::lsbdistrelease == '14.04' {
+  if ($::lsbdistid == 'Ubuntu' and versioncmp($::lsbdistrelease, '14.04') >= 0)
+    or ($::lsbdistid == 'Debian' and versioncmp($::lsbdistrelease, '7.0') >= 0) {
+
     ensure_packages(['libc6-i386', 'lib32stdc++6', 'lib32gcc1', 'lib32ncurses5', 'lib32z1'])
   }
 }

--- a/manifests/sdk.pp
+++ b/manifests/sdk.pp
@@ -12,6 +12,7 @@
 # Copyright 2012 MaestroDev, unless otherwise noted.
 #
 class android::sdk {
+
   include android::paths
   include wget
 
@@ -44,9 +45,9 @@ class android::sdk {
     command => $unpack_command,
     creates => $android::paths::sdk_home,
     cwd     => $android::paths::installdir,
-  }->
+  } ->
   file { 'android-executable':
-    ensure => present,
+    ensure => file,
     path   => "${android::paths::toolsdir}/android",
     owner  => $android::user,
     group  => $android::group,
@@ -58,11 +59,16 @@ class android::sdk {
   if ($::kernel == 'Linux') and ($::architecture == 'x86_64' or $::architecture == 'amd64') and $::lsbdistrelease != '14.04' {
     ensure_packages($::osfamily ? {
       'RedHat' => ['glibc.i686','zlib.i686','libstdc++.i686','zlib','libstdc++'],
+
+    $packages = $::osfamily ? {
       # List 64-bit version and use latest for installation too so that the same
       # version is applied to both.
+      'RedHat' => ['glibc.i686', 'zlib.i686', 'libstdc++.i686', 'zlib', 'libstdc++'],
       'Debian' => ['ia32-libs'],
       default  => [],
-    })
+    }
+
+    ensure_packages($packages)
   }
 
   if $::lsbdistrelease == '14.04' {

--- a/manifests/sdk.pp
+++ b/manifests/sdk.pp
@@ -1,7 +1,7 @@
 # == Class: android::sdk
 #
 # This downloads and unpacks the Android SDK. It also
-# installs necessary 32bit libraries for 64bit Linux systems.
+# installs necessary 32-bit libraries for 64-bit Linux systems.
 #
 # === Authors
 #
@@ -53,12 +53,13 @@ class android::sdk {
     mode   => '0755',
   }
 
-  # For 64bit systems, we need to install some 32bit libraries for the SDK
+  # For 64-bit systems, we need to install some 32-bit libraries for the SDK
   # to work.
   if ($::kernel == 'Linux') and ($::architecture == 'x86_64' or $::architecture == 'amd64') and $::lsbdistrelease != '14.04' {
     ensure_packages($::osfamily ? {
-      # list 64-bit version and use latest for installation too so that the same version is applied to both
       'RedHat' => ['glibc.i686','zlib.i686','libstdc++.i686','zlib','libstdc++'],
+      # List 64-bit version and use latest for installation too so that the same
+      # version is applied to both.
       'Debian' => ['ia32-libs'],
       default  => [],
     })

--- a/manifests/sdk.pp
+++ b/manifests/sdk.pp
@@ -1,7 +1,7 @@
 # == Class: android::sdk
 #
-# This downloads and unpacks the Android SDK. It also
-# installs necessary 32-bit libraries for 64-bit Linux systems.
+# This downloads and unpacks the Android SDK. It also installs the necessary
+# 32-bit libraries for 64-bit Linux systems.
 #
 # === Authors
 #

--- a/manifests/system_images.pp
+++ b/manifests/system_images.pp
@@ -10,10 +10,12 @@
 #
 # Copyright 2013 Philip Schiffer
 #
-define android::system_images() {
+define android::system_images(
+  $revision = 'present',
+) {
 
-  android::package{ $title:
-    type => 'system-images',
+  android::package { $title:
+    revision => $revision,
+    type     => 'system-images',
   }
-
 }

--- a/manifests/system_images.pp
+++ b/manifests/system_images.pp
@@ -1,6 +1,16 @@
-# == Class: android::system_images
+# == Define: android::system_images
 #
-# Installs the Android SDK system-images.
+# Installs an Android SDK system image package.
+#
+# === Examples
+#
+# To install a system image package:
+#   android::system_images { 'sys-img-armeabi-v7a-android-23': }
+#
+# === Parameters
+#
+# [*revision*] The revision number of the specified system image package or a
+#   value of 'latest' or 'present'
 #
 # === Authors
 #
@@ -8,7 +18,7 @@
 #
 # === Copyright
 #
-# Copyright 2013 Philip Schiffer
+# Copyright 2013 Philip Schiffer, unless otherwise noted.
 #
 define android::system_images(
   $revision = 'present',

--- a/metadata.json
+++ b/metadata.json
@@ -2,12 +2,12 @@
   "name": "maestrodev-android",
   "version": "1.3.2",
   "author": "maestrodev",
-  "summary": "Android SDK module for Puppet",
+  "summary": "Android SDK and NDK module for Puppet",
   "license": "Apache-2.0",
   "source": "http://github.com/maestrodev/puppet-android",
   "project_page": "http://github.com/maestrodev/puppet-android",
   "issues_url": "https://github.com/maestrodev/puppet-android/issues",
-  "description": "A Puppet module to install the Android SDK.",
+  "description": "A Puppet module to install the Android SDK and NDK.",
   "dependencies": [
     {
       "name": "maestrodev/wget",
@@ -65,7 +65,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
@@ -97,7 +98,9 @@
         "10",
         "11",
         "12",
-        "13"
+        "13",
+        "14",
+        "15"
       ]
     }
   ],

--- a/spec/acceptance/android_system_spec.rb
+++ b/spec/acceptance/android_system_spec.rb
@@ -1,6 +1,6 @@
-require "spec_helper_acceptance"
+require 'spec_helper_acceptance'
 
-describe "android" do
+describe 'android' do
 
   let(:manifest) {
     %Q{
@@ -14,8 +14,8 @@ describe "android" do
     }
   }
 
-  it "android SDK should install" do
-    # Run it twice and test for idempotency
+  it 'android SDK should install' do
+    # Run it twice and test for idempotency.
     apply_manifest(manifest, :catch_failures => true)
     apply_manifest(manifest, :catch_changes => true)
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -18,7 +18,7 @@ describe 'android' do
     }
 
     it { should contain_file("#{dir}/expect-install-platform-tools")
-      .with_content(/android update sdk -u --all -t platform-tools/) }
+      .with_content(/android update sdk -u -a -t platform-tools/) }
     it { should contain_exec('update-android-package-platform-tools')
       .with_command("#{dir}/expect-install-platform-tools") }
 
@@ -45,7 +45,7 @@ describe 'android' do
     } }
 
     it { should contain_file("#{dir}/expect-install-platform-tools")
-      .with_content(/android update sdk -u --all -t platform-tools --proxy-host myhost --proxy-port 1234/) }
+      .with_content(/android update sdk -u -a -t platform-tools --proxy-host myhost --proxy-port 1234/) }
     it { should contain_exec('update-android-package-platform-tools')
       .with_command("#{dir}/expect-install-platform-tools") }
   end
@@ -98,7 +98,7 @@ describe 'android' do
     }
 
     it { should contain_file("#{dir}/expect-install-platform-tools")
-      .with_content(/android update sdk -u --all -t platform-tools --proxy-host myhost --proxy-port 1234/) }
+      .with_content(/android update sdk -u -a -t platform-tools --proxy-host myhost --proxy-port 1234/) }
     it { should contain_exec('update-android-package-platform-tools')
       .with_command("#{dir}/expect-install-platform-tools") }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "android" do
+describe 'android' do
   let(:version) { '22.3' }
   let(:dir) { '/usr/local/android' }
   let(:facts) { {
@@ -12,7 +12,7 @@ describe "android" do
     it { should contain_class('android::sdk') }
     it { should contain_class('android::platform_tools') }
 
-    it { should contain_Wget__Fetch("download-androidsdk").with({ 
+    it { should contain_Wget__Fetch('download-androidsdk').with({
       :source => "http://dl.google.com/android/android-sdk_r#{version}-linux.tgz",
       :destination => "#{dir}/android-sdk_r#{version}-linux.tgz"})
     }
@@ -31,7 +31,7 @@ describe "android" do
     let(:params) { {
       :version => version
     } }
-    it { should contain_Wget__Fetch("download-androidsdk").with({
+    it { should contain_Wget__Fetch('download-androidsdk').with({
       :source => "http://dl.google.com/android/android-sdk_r#{version}-linux.tgz",
       :destination => "#{dir}/android-sdk_r#{version}-linux.tgz"})
     }
@@ -92,7 +92,7 @@ describe "android" do
       :proxy_port => '1234'
     } }
 
-    it { should contain_Wget__Fetch("download-androidsdk").with({
+    it { should contain_Wget__Fetch('download-androidsdk').with({
       :source => "http://dl.google.com/android/android-sdk_r#{version}-macosx.zip",
       :destination => "#{dir}/android-sdk_r#{version}-macosx.zip"})
     }

--- a/spec/classes/ndk_spec.rb
+++ b/spec/classes/ndk_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "android::ndk" do
+describe 'android::ndk' do
 
     let(:pre_condition) { 'include android' }
 

--- a/spec/classes/sdk_spec.rb
+++ b/spec/classes/sdk_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe "android::sdk" do
+describe 'android::sdk' do
   let(:pre_condition) { 'include android' }
 
   context '64bit RedHat', :compile do

--- a/spec/defines/build_tools_spec.rb
+++ b/spec/defines/build_tools_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'android::build_tools', :compile do
+
+  let(:title) { 'build-tools-19.0.1' }
+
+end

--- a/spec/defines/package_spec.rb
+++ b/spec/defines/package_spec.rb
@@ -8,7 +8,7 @@ describe 'android::package' do
     let(:title) { 'android-15' }
     let(:params) { { :type => 'platform' } }
     it { should contain_file("#{dir}/expect-install-android-15")
-      .with_content(/android update sdk -u --all -t android-15/) }
+      .with_content(/android update sdk -u -a -t android-15/) }
     it { should contain_exec('update-android-package-android-15').with({
       :command => "#{dir}/expect-install-android-15",
       :creates => "#{dir}/android-sdk-linux/platforms/android-15",
@@ -32,7 +32,7 @@ describe 'android::package' do
     } }
     let(:title) { 'android-15' }
     let(:params) { { :type => 'platform' } }
-    it { should contain_file("#{dir}/expect-install-android-15").with_content(/android update sdk -u --all -t android-15/) }
+    it { should contain_file("#{dir}/expect-install-android-15").with_content(/android update sdk -u -a -t android-15/) }
     it { should contain_exec('update-android-package-android-15').with({
       :command => "#{dir}/expect-install-android-15",
       :creates => "#{dir}/android-sdk-macosx/platforms/android-15",

--- a/spec/defines/package_spec.rb
+++ b/spec/defines/package_spec.rb
@@ -21,8 +21,8 @@ describe 'android::package' do
     
     it do
       expect {
-        should contain_exec('update-android-package-bad') 
-      }.to raise_error(Puppet::Error, /Unsupported package type: bad/) 
+        should raise_error(Puppet::Error, /Unsupported package type: bad/)
+      }
     end
   end
   

--- a/spec/defines/system_images.rb
+++ b/spec/defines/system_images.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'android::system_images', :compile do
+
+  let(:title) { 'sys-img-armeabi-v7a-android-23' }
+
+end

--- a/templates/expect-script.erb
+++ b/templates/expect-script.erb
@@ -3,14 +3,28 @@
 require 'pty'
 require 'expect'
 
-command="<%= scope.lookupvar('android::paths::sdk_home') %>/tools/android update sdk -u --all -t <%= @title %> <%= @proxy_host %> <%= @proxy_port %>"
-match=%r/^\s*Do you accept the license .* \[y\/n\]:\s*/
-response="y"
+command = "<%= scope.lookupvar('android::paths::sdk_home') %>/tools/android update sdk -u -a -t <%= @title %> <%= @proxy_host %> <%= @proxy_port %>"
+
+dry_mode_command = "#{command} -n"
+dry_mode_match = %r/^\s*Error: Ignoring unknown package filter '<%= @title %>'\s*/
+
+puts dry_mode_command
+
+PTY.spawn(dry_mode_command) do |r, w, pid|
+  begin
+    r.expect(dry_mode_match) do |result|
+      exit 1 unless result.nil?
+    end
+  rescue Errno::EIO, PTY::ChildExited
+  end
+end
+
+match = %r/^\s*Do you accept the license .* \[y\/n\]:\s*/
+response = 'y'
 
 puts command
 
-PTY.spawn(command) do |r,w,p|
-
+PTY.spawn(command) do |r, w, pid|
   w.sync = true
 
   begin
@@ -24,4 +38,5 @@ PTY.spawn(command) do |r,w,p|
 end
 
 exit
+
 #  vim: set ts=2 sw=2 tw=0 et:


### PR DESCRIPTION
1. Add `revision` parameter to `android::package` and related defines:
   1. `present` ensures some revision of the package is installed and does not upgrade the package when a new version is available.
   2. `'n'` ensures that if revision 'n' of the package is installed, then it is not upgraded. Due to limitations of the android tool, if revision 'n' is not installed, then the latest revision will be installed. Fixes #34.
   3. `latest` ensures that the latest revision of the package is installed and upgrades the package when a new version available. Fixes #26.
2. Ensure the NDK is installed by `$android::user` by running the installer as `$android::user`. Fixes #43.
3. Check that a package exists before trying to install it. Fixes #36.
4. Lint and documentation.

(Tested on OS X 10.11, Debian 7, and Ubuntu 14.04, 15.10)
