### PR TITLE
Fixes encoding issues in generated expect script

### DIFF
--- a/templates/expect-script.erb
+++ b/templates/expect-script.erb
@@ -1,5 +1,9 @@
 #!/usr/bin/env ruby
 
+## Fixes 'invalid byte sequence in US-ASCII'
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8
+
 require 'pty'
 require 'expect'
 


### PR DESCRIPTION
We ran into encoding issues when running the installer script. This is an easy fix for the following error.

```
Notice: /Stage[main]/Macbin::Android/Android::Platform[android-23]/Android::Package[android-23]/Exec[update-android-package-android-23]/returns: /usr/local/android/android-sdk-macosx/tools/android update sdk -u --all -t android-23  
Notice: /Stage[main]/Macbin::Android/Android::Platform[android-23]/Android::Package[android-23]/Exec[update-android-package-android-23]/returns: /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/expect.rb:58:in `match': invalid byte sequence in US-ASCII (ArgumentError)
Notice: /Stage[main]/Macbin::Android/Android::Platform[android-23]/Android::Package[android-23]/Exec[update-android-package-android-23]/returns: 	from /System/Library/Frameworks/Ruby.framework/Versions/2.0/usr/lib/ruby/2.0.0/expect.rb:58:in `expect'
Notice: /Stage[main]/Macbin::Android/Android::Platform[android-23]/Android::Package[android-23]/Exec[update-android-package-android-23]/returns: 	from /usr/local/android/expect-install-android-23:21:in `block in <main>'
Notice: /Stage[main]/Macbin::Android/Android::Platform[android-23]/Android::Package[android-23]/Exec[update-android-package-android-23]/returns: 	from /usr/local/android/expect-install-android-23:15:in `spawn'
Notice: /Stage[main]/Macbin::Android/Android::Platform[android-23]/Android::Package[android-23]/Exec[update-android-package-android-23]/returns: 	from /usr/local/android/expect-install-android-23:15:in `<main>'
Error: /usr/local/android/expect-install-android-23 returned 1 instead of one of [0]
```