### PR TITLE
Ubuntu doesn't use ia32-libs from 14.04

### DIFF
--- a/manifests/sdk.pp
+++ b/manifests/sdk.pp
@@ -55,16 +55,17 @@ class android::sdk {
 
   # For 64bit systems, we need to install some 32bit libraries for the SDK
   # to work.
-  if ($::kernel == 'Linux') and ($::architecture == 'x86_64' or $::architecture == 'amd64') and $::lsbdistrelease != '14.04' {
-    ensure_packages($::osfamily ? {
-      # list 64-bit version and use latest for installation too so that the same version is applied to both
-      'RedHat' => ['glibc.i686','zlib.i686','libstdc++.i686','zlib','libstdc++'],
-      'Debian' => ['ia32-libs'],
-      default  => [],
-    })
-  }
 
-  if $::lsbdistrelease == '14.04' {
-    ensure_packages(['libc6-i386', 'lib32stdc++6', 'lib32gcc1', 'lib32ncurses5', 'lib32z1'])
+ if ($::kernel == 'Linux') and ($::architecture == 'x86_64' or $::architecture == 'amd64') {
+ 	if $::lsbdistcodename == 'jessie' or $::lsbdistrelease >= 14.04 { 
+      ensure_packages(["libc6-i386", "lib32stdc++6", "lib32gcc1", "lib32ncurses5", "lib32z1"])
+    } else {
+      ensure_packages($::osfamily ? {
+        # list 64-bit version and use latest for installation too so that the same version is applied to both
+        'RedHat' => ['glibc.i686','zlib.i686','libstdc++.i686','zlib','libstdc++'],
+        'Debian' => ['ia32-libs'],
+        default  => [],
+      })
+    }
   }
 }


### PR DESCRIPTION
Ubuntu from 14.04 doesn't use ia32-libs. Use libc6-i386, lib32stdc++6, lib32gcc1, lib32ncurses5, and lib32z1 instead.

Instead of listing each Ubuntu release by name apply to this rule to releases >= 14.04.
